### PR TITLE
Rename Pillow constant Image.ANTIALIAS to Image.Resampling.LANCZOS

### DIFF
--- a/generator
+++ b/generator
@@ -121,9 +121,9 @@ def worker(queue):
                             interval, output_prefix, size)
             generate_sprite_from_frames(output_prefix, columns,
                                         size, output_file)
-        except:
-            print("[{file_name}] Error occurred with file".format(
-                file_name=file_name))
+        except Exception as e:
+            print("[{file_name}] Error occurred with file: {error}".format(
+                file_name=file_name, error=e))
 
 
 def generate_frames(file_name, video_file_clip, interval, output_prefix, size):

--- a/generator
+++ b/generator
@@ -146,7 +146,7 @@ def extract_frame(video_file_clip, moment, output_prefix, size, frame_count):
 
 def resize_frame(filename, size):
     image = Image.open(filename)
-    image = image.resize(size, Image.ANTIALIAS)
+    image = image.resize(size, Image.Resampling.LANCZOS)
     image.save(filename)
 
 


### PR DESCRIPTION
Hi,

Thank you for the tool, I just came across an issue where generation would fail with updated packages of Pillow:

```
$ /usr/local/bin/python3.10 /Users/bfalzon/scripts/video-thumbnail-generator/generator file.mp4 10 400 225 10 file.jpg
[file.mp4] Extracting frame 1/134
[file.mp4] Error occurred with file
```

Adding some debug produced this error message: `module 'PIL.Image' has no attribute 'ANTIALIAS'`

It appears to be due to Pillow removing the deprecated constant `Image.ANTIALIAS`. Instead, we should use `Image.LANCZOS` or `Image.Resampling.LANCZOS`.

I chose `Image.Resampling.LANCZOS` because in v9.1.0 (Apr 2, 2022 ) this was deprecated when the alternative name because available. Although that was reversed in v9.4.0. So I think either option is fine, and happy to resubmit if we'd like to support pre v9.1.0 releases of Pillow. The more specific constant seemed to be what Pillow would prefer as its own tests refer to this constant path.

I've also added the message to the output by catching just `Exception` which seemed most appropriate and leaving everything unhandled, although we could handle that too and just pass them.

See:
- https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html#antialias-renamed-to-lanczos
- https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#constants
- https://pillow.readthedocs.io/en/stable/releasenotes/9.4.0.html#restored-image-constants
- https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants